### PR TITLE
remove moz prefix from keyframes mixin

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# Upcoming
+
+* Remove moz prefix from keyframes mixin
+
 # 1.2.1
 
 * Allow pseudo element to be passed in to underline mixin

--- a/hover/effects/_keyframes.sass
+++ b/hover/effects/_keyframes.sass
@@ -3,8 +3,5 @@
     @-webkit-keyframes #{$animation-name}
         @content
 
-    @-moz-keyframes #{$animation-name}
-        @content
-
     @keyframes #{$animation-name}
         @content


### PR DESCRIPTION
we don't need it for most browser support, see #18 for discussion.

I decided to leave the prefixes one as is because everything but webkit is defaulted to false anyway, so there's no real harm having them there

@incuna/frontend please review
